### PR TITLE
refactor: only check latest kubescape version if user choose so

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -855,7 +855,7 @@ export class KubescapeApi {
             /* ---------------------------------------------------------------*/
             ui.debug(`Kubescape requested version: ${configs.version}`)
 
-            if (!needsUpdate) {
+            if (!needsUpdate && configs.version === "latest") {
                 /* kubescape exists - check version match */
                 this._versionInfo = await this.getKubescapeVersion()
                 if (configs.version !== this.version) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -489,7 +489,7 @@ export class KubescapeApi {
         return kubescapeCommand
     }
 
-    private async getKubescapeVersion(): Promise<KubescapeVersion> {
+    private async getKubescapeVersion(kind: string): Promise<KubescapeVersion> {
         if (!this.isInstalled) {
             throw new Error(ERROR_KUBESCAPE_NOT_INSTALLED)
         }
@@ -511,9 +511,12 @@ export class KubescapeApi {
                 let match = stdout.match(verRegex)
                 if (match) {
                     verInfo.version = match[0]
-
-                    const latestVersion = await getLatestVersion()
-                    verInfo.isLatest = latestVersion === verInfo.version
+                    if (kind === "latest") {
+                        const latestVersion = await getLatestVersion()
+                        verInfo.isLatest = latestVersion === verInfo.version
+                    } else {
+                        verInfo.isLatest = false
+                    }
                 }
 
                 resolve(verInfo)
@@ -855,9 +858,9 @@ export class KubescapeApi {
             /* ---------------------------------------------------------------*/
             ui.debug(`Kubescape requested version: ${configs.version}`)
 
-            if (!needsUpdate && configs.version === "latest") {
+            if (!needsUpdate) {
                 /* kubescape exists - check version match */
-                this._versionInfo = await this.getKubescapeVersion()
+                this._versionInfo = await this.getKubescapeVersion(configs.version)
                 if (configs.version !== this.version) {
                     if (configs.version === TXT_LATEST) {
                         const latestVersionTag = await getLatestVersion()
@@ -882,7 +885,7 @@ export class KubescapeApi {
                 }
 
                 /* Get version again after update */
-                this._versionInfo = await this.getKubescapeVersion()
+                this._versionInfo = await this.getKubescapeVersion(configs.version)
             }
             completedTasks++
             progress(completedTasks / tasksCount)


### PR DESCRIPTION
Hi, thanks for this useful extension and our group are all eager to use it.

Since we are under an air-gapped environment, we already prepared a proxy for VS Code extension installing. However, since the extension will try to check the kubescape binary version during initialization, it is still stucked and we has no other methods to solve it.

I think maybe only to check latest version when user fill in "latest" option in the extension config is a reasonable solution ?

Please let me know your thoughts, thx :)